### PR TITLE
converts all testnet URLs HTTP -> HTTPS

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,8 +11,8 @@ export const DEFAULT_LEGACY_CONFIG = {
 	NETWORKS: ['testnet'],
 	NETWORK_CONFIG: {
 		testnet: {
-			grpc: 'https://testnet1.penumbra.zone',
-			tendermint: 'http://testnet.penumbra.zone:26657',
+			grpc: 'https://grpc.testnet.penumbra.zone',
+			tendermint: 'https://rpc.testnet.penumbra.zone',
 		},
 	},
 	MESSAGES_CONFIG: {
@@ -37,7 +37,7 @@ export const DEFAULT_LEGACY_CONFIG = {
 	},
 }
 
-export const TESTNET_URL = 'http://testnet.penumbra.zone:8080'
+export const TESTNET_URL = 'https://grpc.testnet.penumbra.zone'
 
 export const columnsAllValidator: Array<
 	ColumnDefinitionType<


### PR DESCRIPTION
As of Testnet 53 Himalia, we have working HTTPS for both pd's gRPC service and Tendermint's API. Let's default to those values throughout the config, so we're no longer using HTTP-only network calls.