### PR TITLE
Revert "Use Balances API rather than BalanceByAddress"

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2,7 +2,7 @@ import { ChainParametersRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/
 import {
 	AddressByIndexRequest,
 	AssetsRequest,
-	BalancesRequest,
+	BalanceByAddressRequest,
 	NotesRequest,
 	TransactionInfoByHashRequest,
 	TransactionInfoRequest, TransactionPlannerRequest,
@@ -601,12 +601,12 @@ class BackgroundService extends EventEmitter {
 				// }
 				return this.viewProtocolService.getFMDParameters()
 			},
-			getBalances: async (arg: BalancesRequest) =>
-				this.viewProtocolService.getBalances(arg),
+			getBalanceByAddress: async (arg: BalanceByAddressRequest) =>
+				this.viewProtocolService.getBalanceByAddress(arg),
 			getAddressByIndexProxy: async (request: string) =>
 				this.viewProtocolService.getAddressByIndex(request),
 			getTransactionPlannerProxy: async (request: string) =>
-				this.viewProtocolService.getTransactionPlanner(request),
+				 this.viewProtocolService.getTransactionPlanner(request),
 		}
 	}
 

--- a/src/inpage.ts
+++ b/src/inpage.ts
@@ -7,8 +7,8 @@ import {
 	AddressByIndexRequest,
 	AddressByIndexResponse,
 	AssetsResponse,
-	BalancesRequest,
-	BalancesResponse,
+	BalanceByAddressRequest,
+	BalanceByAddressResponse,
 	ChainParametersResponse,
 	FMDParametersResponse,
 	NotesResponse,
@@ -46,14 +46,14 @@ declare global {
 			cb: (
 				state:
 					| Awaited<
-						ReturnType<
-							| __BackgroundPageApiDirect['requestAccounts']
-							| __BackgroundPageApiDirect['getStatusStream']
-							| __BackgroundPageApiDirect['getTransactionInfo']
-						>
-					>
+							ReturnType<
+								| __BackgroundPageApiDirect['requestAccounts']
+								| __BackgroundPageApiDirect['getStatusStream']
+								| __BackgroundPageApiDirect['getTransactionInfo']
+							>
+					  >
 					| AssetsResponse
-					| BalancesResponse
+					| BalanceByAddressResponse
 					| NotesResponse
 					| TransactionInfoResponse
 					| string[]
@@ -78,8 +78,8 @@ globalThis.penumbra = {
 	signTransaction: proxy.signTransaction,
 	requestAccounts: proxy.requestAccounts,
 	getFullViewingKey: proxy.getFullViewingKey,
-	getBalances: (arg: BalancesRequest) =>
-		proxy.getBalances(arg),
+	getBalanceByAddress: (arg: BalanceByAddressRequest) =>
+		proxy.getBalanceByAddress(arg),
 	getChainParameters: async () =>
 		new ChainParametersResponse().fromJson(
 			(await proxy.getChainParameters()) as any
@@ -123,9 +123,9 @@ globalThis.penumbra = {
 				await timer(100)
 			}
 		} else if (event === 'balance') {
-			const data = await penumbra.getBalances({} as any)
+			const data = await penumbra.getBalanceByAddress({} as any)
 			for (let i = 0; i < data.length; i++) {
-				cb(new BalancesResponse().fromJson(data[i] as any))
+				cb(new BalanceByAddressResponse().fromJson(data[i] as any))
 				await timer(100)
 			}
 		} else if (event === 'status') {
@@ -167,10 +167,10 @@ globalThis.penumbra = {
 				// 	cb(updatedValue)
 				// }
 				else if (event === 'balance') {
-					const data = await penumbra.getBalances({} as any)
+					const data = await penumbra.getBalanceByAddress({} as any)
 
 					for (let i = 0; i < data.length; i++) {
-						cb(new BalancesResponse().fromJson(data[i] as any))
+						cb(new BalanceByAddressResponse().fromJson(data[i] as any))
 						await timer(100)
 					}
 				} else if (event === 'assets') {

--- a/src/services/ViewProtocolService.ts
+++ b/src/services/ViewProtocolService.ts
@@ -6,8 +6,8 @@ import {
 	AddressByIndexRequest,
 	AssetsRequest,
 	AssetsResponse,
-	BalancesRequest,
-	BalancesResponse,
+	BalanceByAddressRequest,
+	BalanceByAddressResponse,
 	ChainParametersRequest,
 	ChainParametersResponse,
 	FMDParametersRequest,
@@ -75,14 +75,14 @@ export class ViewProtocolService {
 		this.getAccountFullViewingKey = getAccountFullViewingKey
 	}
 
-	async getBalances(
-		request?: BalancesRequest
-	): Promise<BalancesResponse[]> {
+	async getBalanceByAddress(
+		request?: BalanceByAddressRequest
+	): Promise<BalanceByAddressResponse[]> {
 		const { balance } = await this.extensionStorage.getState('balance')
 		const assets = await this.indexedDb.getAllValue(ASSET_TABLE_NAME)
 
 		const res = Object.entries(balance).map((i: [string, number]) => {
-			return new BalancesResponse().fromJson({
+			return new BalanceByAddressResponse().fromJson({
 				amount: {
 					lo: i[1],
 					//TODO add hi

--- a/src/types/viewService.ts
+++ b/src/types/viewService.ts
@@ -1,8 +1,8 @@
-export type BalancesReq = {
+export type BalanceByAddressReq = {
 	address: { inner: string }
 }
 
-export type BalancesRes = {
+export type BalanceByAddressRes = {
 	amount: { lo: number }
 	asset: { inner: string }
 }


### PR DESCRIPTION
PR https://github.com/penumbra-zone/wallet/pull/13 targeted main branch, when it should have targeted the dev branch, according to git-flow used for this repo. Undoing the change into main, so main stays pristine and tracks the stable release in the Web Store.

We'll need to follow up and recommit on dev branch.

This reverts commit 915b18572ba6297e0f053a092d2ef9b28576ddd0.